### PR TITLE
Forward port 4000 for ohana-web-search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 ohana-api
+ohana-web-search

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This step can take several minutes, mostly because it takes a while to install a
 
 Verify that you can launch the app:
 
-    vagrant@ohana-api-dev-box:/vagrant/ohana-api$ puma -p 8080
+    vagrant@ohana-api-dev-box:/vagrant/ohana-api$ rails s -p 8080 -b 0.0.0.0
 
 You should now be able to access the app on the host machine at
 http://localhost:8080
@@ -181,7 +181,7 @@ running by pressing ctrl-c. Then press ctrl-d to log out.
 4. Launch Ohana API
  ```
  vagrant@ohana-api-dev-box:~$ cd /vagrant/ohana-api
- vagrant@ohana-api-dev-box:/vagrant/ohana-api$ puma -p 8080
+ vagrant@ohana-api-dev-box:/vagrant/ohana-api$ rails s -p 8080 -b 0.0.0.0
  ```
 
 ### NFS

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,7 @@ Vagrant.configure('2') do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 8080 on the guest machine.
   config.vm.network :forwarded_port, guest: 8080, host: 8080
+  config.vm.network :forwarded_port, guest: 4000, host: 4000
 
   # Enable provisioning with Puppet stand alone.  Puppet manifests
   # are contained in a directory path relative to this Vagrantfile.


### PR DESCRIPTION
This will allow someone to run both ohana-api and ohana-web-search on the same Vagrant machine.